### PR TITLE
Add promise support for webhooks

### DIFF
--- a/src/promised.js
+++ b/src/promised.js
@@ -82,6 +82,9 @@ module.exports = function promised(gateway) {
             submitForSettlement: null,
             void: null,
         },
+        webhookNotification: {
+            parse: null
+        }
     };
 
     for (const name in modules) {


### PR DESCRIPTION
This commit adds support for the webhookNotification.parse function mentioned in https://developers.braintreepayments.com/guides/webhooks/parse/node
This would allow the library to promisify the webhook handler as well as the rest of Braintree's API.
