### PR TITLE
added original braintree error to error

### DIFF
--- a/src/promised.js
+++ b/src/promised.js
@@ -7,7 +7,9 @@ function promiseCallback(object, method) {
                 }
 
                 if (result && result.success === false) {
-                    return reject(new Error(result.message));
+                    var error = new Error(result.message);
+                    error.result = result;
+                    return reject(error);
                 }
 
                 return resolve(result);


### PR DESCRIPTION
When braintree returns error, braintree-as-promised rejects with just error message. This pr adds braintree error to it to rejection error.